### PR TITLE
Fix pages counting content instead of the array (throwing Countable)

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -56,7 +56,7 @@ class Html extends Base
         }
 
         $this->content[$number] = $content;
-        $this->pages = count($this->content[$number]);
+        $this->pages = count($this->content);
         return $this;
     }
 


### PR DESCRIPTION
Fixes (PHP 7.2)  
```php
A PHP Error was encountered
Severity: Warning

Message: count(): Parameter must be an array or an object that implements Countable

Filename: src/Html.php

Line Number: 59

Backtrace:

File: D:\xampp\htdocs\forologia\vendor\tonchik-tm\pdf-to-html\src\Html.php
Line: 59
Function: count

File: D:\xampp\htdocs\forologia\vendor\tonchik-tm\pdf-to-html\src\Pdf.php
Line: 155
Function: addPage

File: D:\xampp\htdocs\forologia\vendor\tonchik-tm\pdf-to-html\src\Pdf.php
Line: 91
Function: getContent
```